### PR TITLE
Update SDfileOpen when file closes in writeCache()

### DIFF
--- a/examples/DefaultBoard/SD_Card_Stuff.ino
+++ b/examples/DefaultBoard/SD_Card_Stuff.ino
@@ -301,7 +301,7 @@ void writeCache(){
       writeFooter();
     }
     if(blockCounter == BLOCK_COUNT){
-      closeSDfile();
+      SDfileOpen = closeSDfile();
       BLOCK_COUNT = 0;
     }  // we did it!
 }


### PR DESCRIPTION
If the file is closed automatically from hitting the block count, update the SdfileOpen boolean