### PR TITLE
Reconfigure lead-off detection every ADS reset

### DIFF
--- a/OpenBCI_32bit_Library.cpp
+++ b/OpenBCI_32bit_Library.cpp
@@ -469,7 +469,7 @@ boolean OpenBCI_32bit_Library::processChar(char character)
       sendEOT();
       break;
     case OPENBCI_GET_VERSION:
-      printAll("v3.1.2");
+      printAll("v3.1.3");
       sendEOT();
       break;
     default:
@@ -791,7 +791,6 @@ void OpenBCI_32bit_Library::boardReset(void)
 {
   initialize(); // initalizes accelerometer and on-board ADS and on-daisy ADS if present
   delay(500);
-  configureLeadOffDetection(LOFF_MAG_6NA, LOFF_FREQ_31p2HZ);
   printlnAll("OpenBCI V3 8-16 channel");
   printAll("On Board ADS1299 Device ID: 0x");
   printlnHex(ADS_getDeviceID(ON_BOARD));
@@ -802,7 +801,7 @@ void OpenBCI_32bit_Library::boardReset(void)
   }
   printAll("LIS3DH Device ID: 0x");
   printlnHex(LIS3DH_getDeviceID());
-  printlnAll("Firmware: v3.1.2");
+  printlnAll("Firmware: v3.1.3");
   sendEOT();
   delay(5);
   wifi.reset();
@@ -1984,6 +1983,7 @@ void OpenBCI_32bit_Library::initialize_ads()
     leadOffSettings[i][PCHAN] = OFF;
     leadOffSettings[i][NCHAN] = OFF;
   }
+  configureLeadOffDetection(LOFF_MAG_6NA, LOFF_FREQ_31p2HZ);
   verbosity = false; // when verbosity is true, there will be Serial feedback
   firstDataPacket = true;
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# v3.1.3
+
+### Bug Fixes
+
+- Fixed impedance measurement following sample rate changes
+
 # v3.1.2
 
 ### Bug Fixes


### PR DESCRIPTION
Previously, this was only done at initial board reset, but this state would
get clobbered any time the sample rate was changed.

Also, this commit bumps the firmware version to 3.1.3.

Addresses #94.